### PR TITLE
Adjust note area padding for symmetric margins

### DIFF
--- a/dropnote/ContentView.swift
+++ b/dropnote/ContentView.swift
@@ -232,8 +232,8 @@ struct ContentView: View {
                         }
                     }
                 }
-                .padding(.top, 6)
-                .padding(.trailing, 10)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 10)
             }
 
             // Buttons unten


### PR DESCRIPTION
### Motivation
- Ensure the editor/preview area inside the popover has equal spacing on all sides so the note content appears with symmetric margins.

### Description
- In `dropnote/ContentView.swift` replaced the asymmetric `.padding(.top, 6)` and `.padding(.trailing, 10)` on the note container with `.padding(.horizontal, 10)` and `.padding(.vertical, 10)` to provide consistent margins around the editor/preview.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819cf1b4fc832a9cc86a88e8634340)