### PR TITLE
Close popover when app loses focus

### DIFF
--- a/dropnote/AppDelegate.swift
+++ b/dropnote/AppDelegate.swift
@@ -26,6 +26,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.contentSize = NSSize(width: 300, height: 400)
         popover.behavior = .transient
         popover.contentViewController = NSHostingController(rootView: ContentView())
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppDidResignActive),
+            name: NSApplication.didResignActiveNotification,
+            object: nil
+        )
         
         applyStartupSetting() // ⬅️ Autostart prüfen & setzen
     }
@@ -38,6 +45,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             }
         }
+    }
+
+    @objc private func handleAppDidResignActive() {
+        popover.performClose(nil)
     }
     
     func applyStartupSetting() {
@@ -58,5 +69,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             print("❌ Autostart error:", error.localizedDescription)
         }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the status-item popover is closed when the app loses focus so the popover does not linger and the status button continues to toggle it correctly on the next click.

### Description
- Register `NSApplication.didResignActiveNotification` in `applicationDidFinishLaunching(_:)` and add `@objc private func handleAppDidResignActive()` that calls `popover.performClose(nil)`, and unregister the observer in `deinit`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819d645208832aa61c1317a480718c)