### PR TITLE
Adjust search bar alignment in ContentView

### DIFF
--- a/dropnote/ContentView.swift
+++ b/dropnote/ContentView.swift
@@ -90,6 +90,7 @@ struct ContentView: View {
                 if isSearching {
                     TextField("Search", text: $searchText)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .frame(maxWidth: .infinity)
                         .transition(.opacity)
                         .focused($isSearchFieldFocused)
                         .onChange(of: isSearchFieldFocused) { focused in
@@ -103,6 +104,7 @@ struct ContentView: View {
                             }
                         }
                 } else {
+                    Spacer()
                     Button(action: {
                         withAnimation { isSearching = true }
                     }) {


### PR DESCRIPTION
### Motivation
- Improve the top search bar layout so the magnifying button is right-aligned when the search field is hidden and the search field can occupy full width when visible for a clearer, more consistent UI.

### Description
- In `dropnote/ContentView.swift` the top search HStack was modified to insert a `Spacer()` before the magnifying button when `!isSearching` and the `TextField` used while `isSearching` now has `.frame(maxWidth: .infinity)` so it expands to the available width.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819d670b1c832aaccbd3afbbf269df)