### PR TITLE
Open Settings from bottom-right gear and remove native menu popup

### DIFF
--- a/dropnote/ContentView.swift
+++ b/dropnote/ContentView.swift
@@ -237,11 +237,7 @@ struct ContentView: View {
             }
 
             // Buttons unten
-<<<<<<< HEAD
-            HStack {
-=======
             HStack(spacing: 16) {
->>>>>>> 457a0e15dc3ed23e0d986ba7afeb13eb84675f76
                 Button(action: addNote) {
                     Image(systemName: "plus")
                 }
@@ -290,11 +286,18 @@ struct ContentView: View {
 
             HStack {
                 Spacer()
-                Button(action: showNativeMenu) {
+                Button(action: {
+                    controller.openSettings(nil)
+                }) {
                     Image(systemName: "gear")
                         .padding(5)
                 }
                 .buttonStyle(BorderlessButtonStyle())
+                .contextMenu {
+                    Button("Quit DropNote") {
+                        controller.quitApp(nil)
+                    }
+                }
             }
         }
         .padding(.top, 8)
@@ -345,19 +348,6 @@ struct ContentView: View {
             if i < lines.count - 1 { result = result + Text("\n") }
         }
         return result
-    }
-
-    func showNativeMenu() {
-        let menu = NSMenu()
-        let settingsItem = NSMenuItem(title: "Settings", action: #selector(controller.openSettings(_:)), keyEquivalent: "")
-        settingsItem.target = controller
-        menu.addItem(settingsItem)
-        menu.addItem(.separator())
-        let quitItem = NSMenuItem(title: "Quit DropNote", action: #selector(controller.quitApp(_:)), keyEquivalent: "q")
-        quitItem.target = controller
-        menu.addItem(quitItem)
-        let mouseLocation = NSEvent.mouseLocation
-        menu.popUp(positioning: nil, at: mouseLocation, in: nil)
     }
 
     func addNote() {


### PR DESCRIPTION
### Motivation
- Keep settings access limited to the bottom-right gear button by opening the Settings window directly from that button and removing the separate native popup that duplicated settings/quit actions.

### Description
- In `dropnote/ContentView.swift` the gear button now calls `controller.openSettings(nil)` directly and the old `showNativeMenu()` function was removed, and a `.contextMenu` with a `Quit DropNote` action calling `controller.quitApp(nil)` was added.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69819d680624832ab10f9237408c7c0c)